### PR TITLE
Set service to snapd.socket for RedHat based OS.s

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,9 @@ class snapd {
 
   $service_name = $facts['os']['name'] ? {
     'Archlinux' => 'snapd.socket',
+    'CentOS'    => 'snapd.socket',
+    'RedHat'    => 'snapd.socket',
+    'Fedora'    => 'snapd.socket',
     default     => 'snapd'
   }
 


### PR DESCRIPTION
Howdy!  snapd was being started over and over again via puppet on CentOS if there were no snaps defined.  This was because the snapd.socket needs to be enabled and started, but the snapd process itself is able to start up and shut down as it sees fit.  I adjusted init.pp to basically copy the setting that ArchLinux was using for CentOS, RedHat, and Fedora.